### PR TITLE
Add PyPI publish workflow and cleanup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check package
+      run: twine check dist/*
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/marionette-tg
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,80 @@
-*.pyc
-marionette_tg.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# PLY parser output
 parsetab.py
 parser.out
+
+# macOS
+.DS_Store
+
+# Project specific
+marionette_tg.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # marionette
 
-[![Python](https://img.shields.io/pypi/pyversions/marionette-tg.svg)](https://pypi.org/project/marionette-tg/)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI](https://img.shields.io/pypi/v/marionette-tg.svg)](https://pypi.org/project/marionette-tg/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![CI](https://github.com/marionette-tg/marionette/actions/workflows/ci.yml/badge.svg)](https://github.com/marionette-tg/marionette/actions/workflows/ci.yml)
+[![Tests](https://github.com/marionette-tg/marionette/actions/workflows/ci.yml/badge.svg)](https://github.com/marionette-tg/marionette/actions/workflows/ci.yml)
 
 **This code is still pre-alpha and is NOT suitable for any real-world deployment.**
 
@@ -22,8 +22,6 @@ Marionette is a programmable client-server proxy that enables the user to contro
 
 ```console
 pip install marionette-tg
-```
-
 ### From Source
 
 ```console
@@ -31,8 +29,6 @@ git clone https://github.com/marionette-tg/marionette.git
 cd marionette
 pip install -r requirements.txt
 pip install -e .
-```
-
 ### System Dependencies
 
 #### Ubuntu/Debian
@@ -40,32 +36,18 @@ pip install -e .
 ```console
 sudo apt-get update
 sudo apt-get install libgmp-dev python3-dev libcurl4-openssl-dev
-```
-
 #### RedHat/Fedora/CentOS
 
 ```console
 sudo dnf install gmp-devel python3-devel libcurl-devel
-```
-
 #### macOS
 
 ```console
 brew install gmp curl
-```
-
 ### Sanity Check
 
 ```console
 python -m pytest marionette_tg/ -v
-```
-
-Or using setup.py:
-
-```console
-python setup.py test
-```
-
 ### Running
 
 And then testing with the servers...
@@ -75,8 +57,6 @@ And then testing with the servers...
 ./bin/marionette_server --server_ip 127.0.0.1 --proxy_ip 127.0.0.1 --proxy_port 8081 --format dummy &
 ./bin/marionette_client --server_ip 127.0.0.1 --client_ip 127.0.0.1 --client_port 8079 --format dummy &
 curl --socks4a 127.0.0.1:8079 example.com
-```
-
 A complete list of options is available with the `--help` parameter.
 
 
@@ -107,8 +87,6 @@ action [block_name]:
   [client | server] [module].[func](arg1, arg2, ...)
   [client | server] [module].[func](arg1, arg2, ...) [if regex_match_incoming(regex)]
 ...
-```
-
 The only `connection_type` currently supported is tcp. The port specifies the port that the server listens on and client connects to. The `block_name` specifies the named action that should be exected when transitioning from src to dst. A single error transition can be specified for each src and will be executed if all other potential transitions from src are impossible.
 
 Action blocks specify actions by either a client or server. For brevity we allow specification of an action, such as `fte.send`
@@ -141,8 +119,6 @@ action http_get:
 
 action http_ok:
   server fte.send("^HTTP/1\.1\ 200 OK\r\nContent-Type:\ ([a-zA-Z0-9]+)\r\n\r\n\C*$", 128)
-```
-
 ### HTTP with error transitions and conditionals
 
 We use error transitions in the following format to deal with incoming connections that aren't from a marionette client. The conditionals are used to match a regex aginst the incoming request.
@@ -165,8 +141,6 @@ action http_ok_err:
   server io.puts("HTTP/1.1 200 OK\r\n\r\nHello, World!") if regex_match_incoming("^GET /(index\.html)? HTTP/1\.(0|1).*")
   server io.puts("HTTP/1.1 404 File Not Found\r\n\r\nFile not found!") if regex_match_incoming("^GET /.* HTTP/1\.(0|1).*")
   server io.puts("HTTP/1.1 400 Bad Request\r\n\r\nBad request!") if regex_match_incoming("^.+")
-```
-
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/marionette_tg/probe_tests.py
+++ b/marionette_tg/probe_tests.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 import os
 import sys
 import time
-import httplib
+import http.client
 import unittest
 
 sys.path.append('.')
@@ -30,11 +30,11 @@ class Tests(unittest.TestCase):
 
     def do_probe(self, request_method, request_uri, expected_response):
         server_listen_ip = marionette_tg.conf.get("server.server_ip")
-        conn = httplib.HTTPConnection(
-            server_listen_ip, 8080, False, timeout=30)
+        conn = http.client.HTTPConnection(
+            server_listen_ip, 8080, timeout=30)
         conn.request(request_method, request_uri)
         response = conn.getresponse()
-        actual_response = response.read()
+        actual_response = response.read().decode('utf-8')
         conn.close()
 
         self.assertEqual(actual_response, expected_response)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 from setuptools import setup, find_packages
@@ -17,11 +17,10 @@ setup(
     url='https://github.com/marionette-tg/marionette',
     license='MIT',
     scripts=['bin/marionette_client', 'bin/marionette_server'],
-    test_suite='marionette_tg',
     packages=find_packages(),
     package_data={'marionette_tg': ['marionette.conf', 'formats/*.mar', 'formats/**/*.mar', 'formats/**/**/*.mar']},
     include_package_data=True,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'twisted>=21.0.0',
         'fte>=0.1.0',
@@ -35,11 +34,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Security',
     ],


### PR DESCRIPTION
## Changes

### README badges
- Renamed "CI" badge to "Tests"
- Fixed Python version badge (was showing "missing" from PyPI, now shows static "3.8+" badge)

### New PyPI publish workflow
- Added `.github/workflows/publish.yml` that automatically publishes to PyPI when a GitHub release is created
- Uses trusted publishing (OIDC) for secure, tokenless authentication

### Cleanup
- Updated `.gitignore` with comprehensive Python patterns (byte-compiled files, build artifacts, IDE files, etc.)
- Fixed `probe_tests.py` for Python 3 (`httplib` -> `http.client`)
- Updated `setup.py`: removed deprecated `test_suite`, require Python 3.8+, added Python 3.12 to classifiers

### Note on PyPI publishing
To use the publish workflow, you'll need to configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/marionette-tg/settings/publishing/
2. Add a new "pending publisher" with:
   - Owner: marionette-tg
   - Repository: marionette
   - Workflow name: publish.yml
   - Environment name: pypi