### PR TITLE
Replace pycurl with requests+PySocks (no system deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install system dependencies
+    - name: Install system dependencies (optional, for performance)
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgmp-dev libcurl4-openssl-dev
+        sudo apt-get install -y libgmp-dev
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install system dependencies (optional, for performance)
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libgmp-dev
-
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 twisted>=25.5.0
 fte>=0.2.1
 ply>=3.11
-pycurl>=7.45.0
+requests>=2.28.0
+PySocks>=1.7.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'twisted>=25.5.0',
         'fte>=0.2.1',
         'ply>=3.11',
-        'pycurl>=7.45.0',
+        'requests>=2.28.0',
+        'PySocks>=1.7.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
## Summary

Replaces `pycurl` with `requests` + `PySocks`, eliminating the need for `libcurl` development headers during installation.