### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("PYPI_README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='marionette-tg',
-    version='0.1.0',
+    version='0.1.1',
     description='Marionette - The polymorphic, programmable proxy.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Bump version from 0.1.0 to 0.1.1 for release.

This version includes fixes for bytes/string encoding issues that were causing the proxy to hang.